### PR TITLE
MKV/MP4 Cover Art in Dolphin?

### DIFF
--- a/ffmpegthumbs.desktop
+++ b/ffmpegthumbs.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Type=Service
 Name=Video Files (ffmpegthumbs)
+Name[ast]=Ficheros de videu (ffmpegthumbs)
 Name[bg]=Видео файлове (ffmpegthumbs)
 Name[bs]=Video datoteke (ffmpegthumbs)
 Name[ca]=Fitxers de vídeo (ffmpegthumbs)


### PR DESCRIPTION
Hi, I'm using Plasma 5.16.1 and for a while now I've been looking tirelessly for a way to get the MKV/MP4 covers in Dolphin, I see that ffmpegthums is based on ffmpegthumbnailer which already have a way to show the covers (https://github.com/dirkvdb/ffmpegthumbnailer/issues/138). Dolphin has greatly improved these latest versions and supports previews for many file types, but still does not show the covers built into the mkv/mp4. Could you add this option to future versions of ffmpegthumbs to view the cover art of video files?